### PR TITLE
Fix vector component names and count cast

### DIFF
--- a/WormBrowser/OWLayer.m
+++ b/WormBrowser/OWLayer.m
@@ -193,13 +193,13 @@
                                 
                             case 3:
                                 
-                                 drawGroup.vertexBufferData[outputStart / strideLength].texCoord.s = decodeScaleVals[j] * (prev + decodeOffsetVals[j]);
+                                drawGroup.vertexBufferData[outputStart / strideLength].texCoord.x = decodeScaleVals[j] * (prev + decodeOffsetVals[j]);
                                 
                                 break;
                                 
                             case 4:
                         
-                                 drawGroup.vertexBufferData[outputStart / strideLength].texCoord.t = decodeScaleVals[j] * (prev + decodeOffsetVals[j]);
+                                drawGroup.vertexBufferData[outputStart / strideLength].texCoord.y = decodeScaleVals[j] * (prev + decodeOffsetVals[j]);
                                 
                                 break;
                                 
@@ -261,7 +261,7 @@
             
             if (bboffset > 0) {
                 
-                int numBBoxen = [[meshDictionary objectForKey:@"names"] count];
+                int numBBoxen = [(NSArray*)[meshDictionary objectForKey:@"names"] count];
                 
                 int numFloats = numBBoxen * 6;
                 int inputStart = bboffset;


### PR DESCRIPTION
## Summary
- fix Metal vector component accessors in `OWLayer`
- cast bounding box name array to avoid count ambiguity

## Testing
- `./setup.sh`
- `pod install --allow-root`


------
https://chatgpt.com/codex/tasks/task_b_68636b3cbf68832aadf1eb1ba2e20bd9