### PR TITLE
Fix iOS deprecation warnings

### DIFF
--- a/Pods/DCRoundSwitch/DCRoundSwitch/DCRoundSwitch.m
+++ b/Pods/DCRoundSwitch/DCRoundSwitch/DCRoundSwitch.m
@@ -173,8 +173,8 @@
 	NSString *onString = self.toggleLayer.onString;
 	NSString *offString = self.toggleLayer.offString;
 
-	CGFloat width = [onString sizeWithFont:self.toggleLayer.labelFont].width;
-	CGFloat offWidth = [offString sizeWithFont:self.toggleLayer.labelFont].width;
+        CGFloat width = [onString sizeWithAttributes:@{NSFontAttributeName: self.toggleLayer.labelFont}].width;
+        CGFloat offWidth = [offString sizeWithAttributes:@{NSFontAttributeName: self.toggleLayer.labelFont}].width;
 	
 	if(offWidth > width)
 		width = offWidth;

--- a/Pods/DCRoundSwitch/DCRoundSwitch/DCRoundSwitchToggleLayer.m
+++ b/Pods/DCRoundSwitch/DCRoundSwitch/DCRoundSwitchToggleLayer.m
@@ -81,20 +81,20 @@
 	UIGraphicsPushContext(context);
 
 	// 'ON' state label (self.onString)
-	CGSize onTextSize = [self.onString sizeWithFont:self.labelFont];
+        CGSize onTextSize = [self.onString sizeWithAttributes:@{NSFontAttributeName: self.labelFont}];
 	CGPoint onTextPoint = CGPointMake((textSpaceWidth - onTextSize.width) / 2.0 + knobRadius * .15, floorf((self.bounds.size.height - onTextSize.height) / 2.0) + 1.0);
 	[[UIColor colorWithWhite:0.45 alpha:1.0] set]; // .2 & .4
-	[self.onString drawAtPoint:CGPointMake(onTextPoint.x, onTextPoint.y - 1.0) withFont:self.labelFont];
+        [self.onString drawAtPoint:CGPointMake(onTextPoint.x, onTextPoint.y - 1.0) withAttributes:@{NSFontAttributeName: self.labelFont}];
 	[[UIColor whiteColor] set];
-	[self.onString drawAtPoint:onTextPoint withFont:self.labelFont];
+        [self.onString drawAtPoint:onTextPoint withAttributes:@{NSFontAttributeName: self.labelFont}];
 
 	// 'OFF' state label (self.offString)
-	CGSize offTextSize = [self.offString sizeWithFont:self.labelFont];
+        CGSize offTextSize = [self.offString sizeWithAttributes:@{NSFontAttributeName: self.labelFont}];
 	CGPoint offTextPoint = CGPointMake(textSpaceWidth + (textSpaceWidth - offTextSize.width) / 2.0 + knobRadius * .86, floorf((self.bounds.size.height - offTextSize.height) / 2.0) + 1.0);
 	[[UIColor whiteColor] set];
-	[self.offString drawAtPoint:CGPointMake(offTextPoint.x, offTextPoint.y + 1.0) withFont:self.labelFont];
+        [self.offString drawAtPoint:CGPointMake(offTextPoint.x, offTextPoint.y + 1.0) withAttributes:@{NSFontAttributeName: self.labelFont}];
 	[[UIColor colorWithWhite:0.52 alpha:1.0] set];
-	[self.offString drawAtPoint:offTextPoint withFont:self.labelFont];
+        [self.offString drawAtPoint:offTextPoint withAttributes:@{NSFontAttributeName: self.labelFont}];
 
 	UIGraphicsPopContext();
 }

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -125,12 +125,12 @@
 		2F7EF43285834E1201CFF1EDC7DCFB61 /* DDLoggerNames.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLoggerNames.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDLoggerNames.h; sourceTree = "<group>"; };
 		3DE7BBF5A6D17D198AF583B494DE001A /* Reachability-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Reachability-dummy.m"; sourceTree = "<group>"; };
 		3E195221B09C16FBF67F463C799B7027 /* DCRoundSwitch-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DCRoundSwitch-prefix.pch"; sourceTree = "<group>"; };
-		400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = Reachability; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		494E57B7666B0407CCA71448249CCBC8 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAbstractDatabaseLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
 		4FE113951B345F8CD435B2A92EA0744F /* DDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDMultiFormatter.m; path = Sources/CocoaLumberjack/Extensions/DDMultiFormatter.m; sourceTree = "<group>"; };
-		519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaLumberjackPrivacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		5743B0089D8EB12DE16A9B85BF5AC571 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/CocoaLumberjack/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenWorm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "CocoaLumberjack-CocoaLumberjackPrivacy"; path = CocoaLumberjackPrivacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		5743B0089D8EB12DE16A9B85BF5AC571 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Sources/CocoaLumberjack/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "Pods-OpenWorm"; path = "libPods-OpenWorm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5888868ED4BEBE305471BEE2622337A3 /* DDFileLogger+Buffering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDFileLogger+Buffering.h"; path = "Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger+Buffering.h"; sourceTree = "<group>"; };
 		5B682BF47B2CB06FE9190393E3A2C0D4 /* Pods-OpenWorm-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OpenWorm-acknowledgements.markdown"; sourceTree = "<group>"; };
 		60746F4531504667F98843E3B0E8F5F0 /* DCRoundSwitchToggleLayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitchToggleLayer.m; path = DCRoundSwitch/DCRoundSwitchToggleLayer.m; sourceTree = "<group>"; };
@@ -141,7 +141,7 @@
 		6EE1D9276F2588288752619612A90EDB /* iRate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = iRate.m; path = iRate/iRate.m; sourceTree = "<group>"; };
 		70174B601C27883376341DCA6A81D48D /* CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
 		71348348490DF861FF39BB5ADFCD2A2F /* DDFileLogger+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDFileLogger+Internal.h"; path = "Sources/CocoaLumberjack/DDFileLogger+Internal.h"; sourceTree = "<group>"; };
-		76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libiRate.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		76E6C06FD221258CB81F365A325A0A03 /* iRate */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = iRate; path = libiRate.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		77C82E0ED1D94173CECA22D81BE81092 /* iRate.bundle */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.plug-in"; name = iRate.bundle; path = iRate/iRate.bundle; sourceTree = "<group>"; };
 		7811DF291458E5024EE55468B812ED48 /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDASLLogCapture.h; sourceTree = "<group>"; };
 		797B444314D41B0225573CA930DC7F0C /* DCRoundSwitch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitch.m; path = DCRoundSwitch/DCRoundSwitch.m; sourceTree = "<group>"; };
@@ -159,7 +159,7 @@
 		98ACEBEC52410175AC1FA1757C527583 /* DCRoundSwitch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DCRoundSwitch.debug.xcconfig; sourceTree = "<group>"; };
 		9905349679C288EF642F67ACF9ADF3F0 /* iRate.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iRate.debug.xcconfig; sourceTree = "<group>"; };
 		9A2B538B7EEB42FC2FCB04D6298F86DB /* DCRoundSwitch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DCRoundSwitch.release.xcconfig; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9FA32E3D557E999064508143EF45E1F9 /* iRate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iRate.release.xcconfig; sourceTree = "<group>"; };
 		A7643FE72683433F275FB0FE106E3553 /* CLIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLIColor.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/CLIColor.h; sourceTree = "<group>"; };
 		A930A47E42A97CED8C01D575EF319645 /* DDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDOSLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h; sourceTree = "<group>"; };
@@ -168,8 +168,8 @@
 		B20B830C516C80274083E737A1280B7C /* Pods-OpenWorm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OpenWorm.release.xcconfig"; sourceTree = "<group>"; };
 		BA05E44D2ECC2BA45EE100AAA0838A07 /* Reachability.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.debug.xcconfig; sourceTree = "<group>"; };
 		C0AE088B28288B8E48899C044548CC0F /* DDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDOSLogger.m; path = Sources/CocoaLumberjack/DDOSLogger.m; sourceTree = "<group>"; };
-		C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libDCRoundSwitch.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = CocoaLumberjack; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = DCRoundSwitch; path = libDCRoundSwitch.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7158AF2308F5A08A9324EE6A13D1877 /* iRate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iRate-prefix.pch"; sourceTree = "<group>"; };
 		C7886F9C3E74DFEF89F52B15DA7EA9B8 /* Reachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		C9A594C871F09029A4BFEFD8A30D39DD /* DCRoundSwitchKnobLayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitchKnobLayer.m; path = DCRoundSwitch/DCRoundSwitchKnobLayer.m; sourceTree = "<group>"; };
@@ -182,9 +182,9 @@
 		DD675D3B8A66E85F612E60E50A3A3EC9 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Sources/CocoaLumberjack/DDFileLogger.m; sourceTree = "<group>"; };
 		DF578159E4926B5E2E91689E080B83A5 /* Reachability.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.release.xcconfig; sourceTree = "<group>"; };
 		DF9987B561ACDBC060BCA503E9E2F180 /* Pods-OpenWorm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OpenWorm.debug.xcconfig"; sourceTree = "<group>"; };
-		DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Reachability_Privacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Reachability-Reachability_Privacy"; path = Reachability_Privacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0D5E8837D4B39548FDCC42079A6CA0B /* CLIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CLIColor.m; path = Sources/CocoaLumberjack/CLI/CLIColor.m; sourceTree = "<group>"; };
-		E394A4FF266A1D33C60CBAE6D2B1D4BA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Framework/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E394A4FF266A1D33C60CBAE6D2B1D4BA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Framework/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E6BADD1BF23935D488D0E8A78329607A /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDDispatchQueueLogFormatter.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
 		EB8C56162F8081FB2F769EB506C5036D /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Sources/CocoaLumberjack/DDASLLogger.m; sourceTree = "<group>"; };
 		F00F03D7545ECE48AC9A728C03215CC7 /* Reachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
@@ -292,13 +292,13 @@
 		3494C746B091FF2FEF7E6AEA9ED02A9F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */,
-				519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */,
-				C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */,
-				76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */,
-				57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */,
-				400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */,
-				DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */,
+				C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */,
+				519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */,
+				C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */,
+				76E6C06FD221258CB81F365A325A0A03 /* iRate */,
+				57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */,
+				400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */,
+				DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -332,6 +332,7 @@
 				50D6C6F19FBBD23B28EAA656500175D3 /* Resources */,
 				291F9BEE532815CC6E150AD4C117B4BD /* Support Files */,
 			);
+			name = iRate;
 			path = iRate;
 			sourceTree = "<group>";
 		};
@@ -415,6 +416,7 @@
 				6CC89E93FE4FBFC14619B5097B55B6B1 /* Resources */,
 				3C52E620797B0F19BB1A8A074212EFF8 /* Support Files */,
 			);
+			name = Reachability;
 			path = Reachability;
 			sourceTree = "<group>";
 		};
@@ -424,6 +426,7 @@
 				9D362EB491872DE015C0AE0B90C34347 /* Core */,
 				155B049BE5630BAA7FECAF537B563E41 /* Support Files */,
 			);
+			name = CocoaLumberjack;
 			path = CocoaLumberjack;
 			sourceTree = "<group>";
 		};
@@ -451,6 +454,7 @@
 				60746F4531504667F98843E3B0E8F5F0 /* DCRoundSwitchToggleLayer.m */,
 				14AF438157C350154DB63AA1E5C4F990 /* Support Files */,
 			);
+			name = DCRoundSwitch;
 			path = DCRoundSwitch;
 			sourceTree = "<group>";
 		};
@@ -553,7 +557,7 @@
 			);
 			name = "CocoaLumberjack-CocoaLumberjackPrivacy";
 			productName = CocoaLumberjackPrivacy;
-			productReference = 519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */;
+			productReference = 519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */;
 			productType = "com.apple.product-type.bundle";
 		};
 		84126886E76D449731B0A0FCF67406CF /* iRate */ = {
@@ -570,7 +574,7 @@
 			);
 			name = iRate;
 			productName = iRate;
-			productReference = 76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */;
+			productReference = 76E6C06FD221258CB81F365A325A0A03 /* iRate */;
 			productType = "com.apple.product-type.library.static";
 		};
 		890AB6D76FF473D68D81F32DCA15B7F9 /* Pods-OpenWorm */ = {
@@ -591,7 +595,7 @@
 			);
 			name = "Pods-OpenWorm";
 			productName = "Pods-OpenWorm";
-			productReference = 57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */;
+			productReference = 57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CAA047C0F5E4106F3904E8497FA17F97 /* Reachability */ = {
@@ -609,7 +613,7 @@
 			);
 			name = Reachability;
 			productName = Reachability;
-			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */;
+			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */;
 			productType = "com.apple.product-type.library.static";
 		};
 		D2787856C227A709315E3C9C4355A440 /* Reachability-Reachability_Privacy */ = {
@@ -626,7 +630,7 @@
 			);
 			name = "Reachability-Reachability_Privacy";
 			productName = Reachability_Privacy;
-			productReference = DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */;
+			productReference = DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */;
 			productType = "com.apple.product-type.bundle";
 		};
 		E95654B155D25890BE8E26081FCA8265 /* CocoaLumberjack */ = {
@@ -644,7 +648,7 @@
 			);
 			name = CocoaLumberjack;
 			productName = CocoaLumberjack;
-			productReference = C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */;
+			productReference = C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F0A37F0DD96DC99AF6475E9E60E7BCD0 /* DCRoundSwitch */ = {
@@ -661,7 +665,7 @@
 			);
 			name = DCRoundSwitch;
 			productName = DCRoundSwitch;
-			productReference = C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */;
+			productReference = C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -674,7 +678,7 @@
 				LastUpgradeCheck = 1600;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -682,6 +686,8 @@
 				en,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 3494C746B091FF2FEF7E6AEA9ED02A9F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -833,36 +839,56 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0952EC8732CB933CFEF9740957D96CD6 /* Release */ = {
+		0E7E001F19F410471D5D45377C1F61FB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B20B830C516C80274083E737A1280B7C /* Pods-OpenWorm.release.xcconfig */;
+			baseConfigurationReference = 98ACEBEC52410175AC1FA1757C527583 /* DCRoundSwitch.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				MACH_O_TYPE = staticlib;
+				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = DCRoundSwitch;
+				PRODUCT_NAME = DCRoundSwitch;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = Debug;
 		};
-		0D1CBAD0A203227A2B9FBC171A097920 /* Release */ = {
+		3291DBCBC96175FAE300070DFB44ADF5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DF578159E4926B5E2E91689E080B83A5 /* Reachability.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Reachability";
+				IBSC_MODULE = Reachability;
+				INFOPLIST_FILE = "Target Support Files/Reachability/ResourceBundle-Reachability_Privacy-Reachability-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = Reachability_Privacy;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		3CA243E3FD30852F37037ABF64B1F091 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BA05E44D2ECC2BA45EE100AAA0838A07 /* Reachability.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -883,77 +909,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_VERSION = 4.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		3291DBCBC96175FAE300070DFB44ADF5 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF578159E4926B5E2E91689E080B83A5 /* Reachability.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Reachability";
-				IBSC_MODULE = Reachability;
-				INFOPLIST_FILE = "Target Support Files/Reachability/ResourceBundle-Reachability_Privacy-Reachability-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				PRODUCT_NAME = Reachability_Privacy;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		32CAB919D5E181ED2393740EEFB63A86 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF9987B561ACDBC060BCA503E9E2F180 /* Pods-OpenWorm.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				MACH_O_TYPE = staticlib;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		3BA6462D7D9DD5944AE6F689F458251E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2E3DADC4D9E71559F5F8B26AEB942498 /* CocoaLumberjack.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = CocoaLumberjack;
-				PRODUCT_NAME = CocoaLumberjack;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 5.8;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1024,34 +979,59 @@
 			};
 			name = Debug;
 		};
-		61FA9D98D918F22E2E7CE8DCFE11CC80 /* Debug */ = {
+		5276D3002A0E2E9B43680EF1A9B61A62 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BA05E44D2ECC2BA45EE100AAA0838A07 /* Reachability.debug.xcconfig */;
+			baseConfigurationReference = 9A2B538B7EEB42FC2FCB04D6298F86DB /* DCRoundSwitch.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = Reachability;
-				PRODUCT_NAME = Reachability;
+				PRODUCT_MODULE_NAME = DCRoundSwitch;
+				PRODUCT_NAME = DCRoundSwitch;
 				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 4.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
-			name = Debug;
+			name = Release;
+		};
+		65BB6A3281079DD69EC2DB2F4425C8E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B20B830C516C80274083E737A1280B7C /* Pods-OpenWorm.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		72B2A0D4F133C17FE518D07F1CCBB80B /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1061,7 +1041,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CocoaLumberjack";
 				IBSC_MODULE = CocoaLumberjack;
 				INFOPLIST_FILE = "Target Support Files/CocoaLumberjack/ResourceBundle-CocoaLumberjackPrivacy-CocoaLumberjack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = CocoaLumberjackPrivacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1078,7 +1058,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CocoaLumberjack";
 				IBSC_MODULE = CocoaLumberjack;
 				INFOPLIST_FILE = "Target Support Files/CocoaLumberjack/ResourceBundle-CocoaLumberjackPrivacy-CocoaLumberjack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = CocoaLumberjackPrivacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1086,33 +1066,6 @@
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
-		};
-		8A22D16B19B62CD8273BB98F00CB1B59 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9905349679C288EF642F67ACF9ADF3F0 /* iRate.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = iRate;
-				PRODUCT_NAME = iRate;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
 		};
 		8B5A46FF8D3C1289CDEE3BAFACABCD2A /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1169,9 +1122,40 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Release;
+		};
+		A6409E6B9E8A048273EEC43CD5E2F769 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DF578159E4926B5E2E91689E080B83A5 /* Reachability.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = Reachability;
+				PRODUCT_NAME = Reachability;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 4.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -1192,68 +1176,11 @@
 			};
 			name = Debug;
 		};
-		AD9A1D6CF5A2DFE550CC87B39B278D64 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9FA32E3D557E999064508143EF45E1F9 /* iRate.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = iRate;
-				PRODUCT_NAME = iRate;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		BF988A6E9DB4BE1F9ED0D02B2E4E01AC /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9A2B538B7EEB42FC2FCB04D6298F86DB /* DCRoundSwitch.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = DCRoundSwitch;
-				PRODUCT_NAME = DCRoundSwitch;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		D7EAB76405B8C06B5115AFB4F357470F /* Release */ = {
+		C38E88462CAB2EAD6D819B73D4AA70A9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 02EC7B05C680059A91DC50FF17E3E18E /* CocoaLumberjack.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1262,7 +1189,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1279,30 +1206,110 @@
 			};
 			name = Release;
 		};
-		DFB8EBDD4036FA7A3F5EFA4481CD403D /* Debug */ = {
+		CF1DAB360E65024F9AE6B0DD4D07D277 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 98ACEBEC52410175AC1FA1757C527583 /* DCRoundSwitch.debug.xcconfig */;
+			baseConfigurationReference = 9FA32E3D557E999064508143EF45E1F9 /* iRate.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = iRate;
+				PRODUCT_NAME = iRate;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D56A61443B0DD14F4542E0FABA4963AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9905349679C288EF642F67ACF9ADF3F0 /* iRate.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = iRate;
+				PRODUCT_NAME = iRate;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D8980B04FE4C0A4A349CF44766A54DF2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E3DADC4D9E71559F5F8B26AEB942498 /* CocoaLumberjack.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = DCRoundSwitch;
-				PRODUCT_NAME = DCRoundSwitch;
+				PRODUCT_MODULE_NAME = CocoaLumberjack;
+				PRODUCT_NAME = CocoaLumberjack;
 				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 5.8;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FB143B540CF73020B998D0DC0F6B7D51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DF9987B561ACDBC060BCA503E9E2F180 /* Pods-OpenWorm.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1313,8 +1320,8 @@
 		0AF17889467CC632C5BD7A38012E35B8 /* Build configuration list for PBXNativeTarget "DCRoundSwitch" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DFB8EBDD4036FA7A3F5EFA4481CD403D /* Debug */,
-				BF988A6E9DB4BE1F9ED0D02B2E4E01AC /* Release */,
+				0E7E001F19F410471D5D45377C1F61FB /* Debug */,
+				5276D3002A0E2E9B43680EF1A9B61A62 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1322,8 +1329,8 @@
 		2E4A01601DDD6A6FCA770BC977523E41 /* Build configuration list for PBXNativeTarget "CocoaLumberjack" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3BA6462D7D9DD5944AE6F689F458251E /* Debug */,
-				D7EAB76405B8C06B5115AFB4F357470F /* Release */,
+				D8980B04FE4C0A4A349CF44766A54DF2 /* Debug */,
+				C38E88462CAB2EAD6D819B73D4AA70A9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1340,8 +1347,8 @@
 		68D7A03F4ED10B9EB56C528D64773381 /* Build configuration list for PBXNativeTarget "Pods-OpenWorm" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				32CAB919D5E181ED2393740EEFB63A86 /* Debug */,
-				0952EC8732CB933CFEF9740957D96CD6 /* Release */,
+				FB143B540CF73020B998D0DC0F6B7D51 /* Debug */,
+				65BB6A3281079DD69EC2DB2F4425C8E8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1349,8 +1356,8 @@
 		7A0974B5C2020827E6DD5133A2522A53 /* Build configuration list for PBXNativeTarget "Reachability" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				61FA9D98D918F22E2E7CE8DCFE11CC80 /* Debug */,
-				0D1CBAD0A203227A2B9FBC171A097920 /* Release */,
+				3CA243E3FD30852F37037ABF64B1F091 /* Debug */,
+				A6409E6B9E8A048273EEC43CD5E2F769 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1367,8 +1374,8 @@
 		EC6E22AC7ABC7D14B32024D9DC6A25E7 /* Build configuration list for PBXNativeTarget "iRate" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8A22D16B19B62CD8273BB98F00CB1B59 /* Debug */,
-				AD9A1D6CF5A2DFE550CC87B39B278D64 /* Release */,
+				D56A61443B0DD14F4542E0FABA4963AC /* Debug */,
+				CF1DAB360E65024F9AE6B0DD4D07D277 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/iRate/iRate/iRate.m
+++ b/Pods/iRate/iRate/iRate.m
@@ -849,7 +849,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         if (!manual && [SKStoreReviewController class])
         {
             [self remindLater];
-            [SKStoreReviewController requestReview];
+            if (@available(iOS 14.0, *)) {
+                UIWindowScene *scene = UIApplication.sharedApplication.windows.firstObject.windowScene;
+                [SKStoreReviewController requestReviewInScene:scene];
+            } else {
+                [SKStoreReviewController requestReview];
+            }
         }
         else
 #endif

--- a/WormBrowser/OWMetaDataViewController.h
+++ b/WormBrowser/OWMetaDataViewController.h
@@ -32,11 +32,12 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
 /** OWMetaDataViewController description
  
 */
-@interface OWMetaDataViewController : UIViewController <UIWebViewDelegate>
+@interface OWMetaDataViewController : UIViewController <WKNavigationDelegate>
 
 
 

--- a/WormBrowser/OWMetaDataViewController.m
+++ b/WormBrowser/OWMetaDataViewController.m
@@ -39,7 +39,7 @@
 }
 
 @property(nonatomic, strong) UIButton* mShowMetaDataButton;
-@property(nonatomic, strong) UIWebView* metaDataView;
+@property(nonatomic, strong) WKWebView* metaDataView;
 
 @end
 
@@ -63,14 +63,9 @@
     
     [self.view setBackgroundColor:[UIColor blackColor]];
     
-    self.metaDataView  = [[UIWebView alloc] initWithFrame:[self frameForWebView]];
+    self.metaDataView  = [[WKWebView alloc] initWithFrame:[self frameForWebView]];
     [self.metaDataView setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
-    [self.metaDataView setDelegate:self];
-    [self.metaDataView setScalesPageToFit:YES];
-    
-    for(UIView *wview in [[[self.metaDataView subviews] objectAtIndex:0] subviews]) {
-        if([wview isKindOfClass:[UIImageView class]]) { wview.hidden = YES; }
-    }
+    self.metaDataView.navigationDelegate = self;
     
     [self.view addSubview:self.metaDataView];
     
@@ -154,18 +149,22 @@
 }
 
 
--(BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+- (void)webView:(WKWebView *)webView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
-    NSRange contains = [request.URL.absoluteString rangeOfString:@".app"];
-    
+    NSURL *url = navigationAction.request.URL;
+    NSRange contains = [url.absoluteString rangeOfString:@".app"];
+
     if (contains.location == NSNotFound) {
-        
-        [[UIApplication sharedApplication] openURL:request.URL];
-        
-        return NO;
-    }
-    else{
-        return YES;
+        if (@available(iOS 10.0, *)) {
+            [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:url];
+        }
+        decisionHandler(WKNavigationActionPolicyCancel);
+    } else {
+        decisionHandler(WKNavigationActionPolicyAllow);
     }
 }
 

--- a/WormBrowser/OWMetalViewController.m
+++ b/WormBrowser/OWMetalViewController.m
@@ -425,9 +425,9 @@ static inline matrix_float4x4 matrix_look_at(vector_float3 eye, vector_float3 ce
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         BOOL isLandscape = size.width > size.height;
         if (isLandscape) {
-            [self.mNavigate setAspectRatio:fabsf(size.height / size.width)];
+            [self.mNavigate setAspectRatio:fabs(size.height / size.width)];
         } else {
-            [self.mNavigate setAspectRatio:fabsf(size.width / size.height)];
+            [self.mNavigate setAspectRatio:fabs(size.width / size.height)];
         }
         [self.mNavigate recalculate];
     } completion:nil];
@@ -438,7 +438,7 @@ static inline matrix_float4x4 matrix_look_at(vector_float3 eye, vector_float3 ce
     [OWInterpolant tweenAll:self.mLayerOpacityInterpolants];
 
     OWCamera *cam = [self.mNavigate getCamera];
-    float aspect = fabsf(self.view.bounds.size.width / self.view.bounds.size.height);
+    float aspect = fabs(self.view.bounds.size.width / self.view.bounds.size.height);
     matrix_float4x4 proj = matrix_perspective(OWDegreesToRadians(40.0f), aspect, 0.1f, 250.0f);
     vector_float3 eye = {cam.eye.x, cam.eye.y, cam.eye.z};
     vector_float3 target = {cam.target.x, cam.target.y, cam.target.z};

--- a/WormBrowser/OWSearchViewController.m
+++ b/WormBrowser/OWSearchViewController.m
@@ -106,7 +106,8 @@
 -(void) setupToolbar
 {
     topToolBar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, kBarThickness)];
-    [topToolBar setBarStyle:UIBarStyleBlackTranslucent];
+    [topToolBar setBarStyle:UIBarStyleBlack];
+    [topToolBar setTranslucent:YES];
     [topToolBar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
     [topToolBar setBackgroundImage:[UIImage imageNamed:@"subtlenet2"] forToolbarPosition:UIToolbarPositionAny barMetrics:UIBarMetricsDefault];
     
@@ -164,51 +165,31 @@
     skinLayerItem = [[UIBarButtonItem alloc] initWithTitle:@"Cut." style:UIBarButtonItemStylePlain target:self action:@selector(handleToolBarTap:)];
 //    [skinLayerItem setTintColor:kWormGreen];
 
-    [skinLayerItem setTitleTextAttributes:
-     @{
-                 UITextAttributeTextColor: kWormGreen,
-                      UITextAttributeFont: fontToUse,
-          UITextAttributeTextShadowOffset: [NSValue valueWithUIOffset:UIOffsetMake(0, 1)],
-           UITextAttributeTextShadowColor: [UIColor colorWithWhite:0.0 alpha:0.5],     
-     }
-                                 forState:UIControlStateNormal];
+    NSShadow *itemShadow = [[NSShadow alloc] init];
+    itemShadow.shadowOffset = CGSizeMake(0, 1);
+    itemShadow.shadowColor = [UIColor colorWithWhite:0.0 alpha:0.5];
+    NSDictionary *titleAttributes = @{
+        NSForegroundColorAttributeName: kWormGreen,
+        NSFontAttributeName: fontToUse,
+        NSShadowAttributeName: itemShadow
+    };
+    [skinLayerItem setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     
     [skinLayerItem setTag:barButton_scrollToSkin];
     [skinLayerItem setWidth:40.0f];
     
     organsLayerItem = [[UIBarButtonItem alloc] initWithTitle:@"Org." style:UIBarButtonItemStylePlain target:self action:@selector(handleToolBarTap:)];
-    [organsLayerItem setTitleTextAttributes:
-     @{
-                 UITextAttributeTextColor: kWormGreen,
-                      UITextAttributeFont: fontToUse,
-          UITextAttributeTextShadowOffset: [NSValue valueWithUIOffset:UIOffsetMake(0, 1)],
-           UITextAttributeTextShadowColor: [UIColor colorWithWhite:0.0 alpha:0.5],
-     }
-                                 forState:UIControlStateNormal];
+    [organsLayerItem setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     [organsLayerItem setTag:barButton_scrollToOrgans];
     [organsLayerItem setWidth:40.0f];
     
     muscleLayerItem = [[UIBarButtonItem alloc] initWithTitle:@"Mus." style:UIBarButtonItemStylePlain target:self action:@selector(handleToolBarTap:)];
-    [muscleLayerItem setTitleTextAttributes:
-     @{
-                 UITextAttributeTextColor: kWormGreen,
-                      UITextAttributeFont: fontToUse,
-          UITextAttributeTextShadowOffset: [NSValue valueWithUIOffset:UIOffsetMake(0, 1)],
-           UITextAttributeTextShadowColor: [UIColor colorWithWhite:0.0 alpha:0.5],
-     }
-                                 forState:UIControlStateNormal];
+    [muscleLayerItem setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     [muscleLayerItem setTag:barButton_scrollToMuscles];
     [muscleLayerItem setWidth:40.0f];    
     
     neuronLayerItem = [[UIBarButtonItem alloc] initWithTitle:@"Neu." style:UIBarButtonItemStylePlain target:self action:@selector(handleToolBarTap:)];
-    [neuronLayerItem setTitleTextAttributes:
-     @{
-                 UITextAttributeTextColor: kWormGreen,
-                      UITextAttributeFont: fontToUse,
-          UITextAttributeTextShadowOffset: [NSValue valueWithUIOffset:UIOffsetMake(0, 1)],
-           UITextAttributeTextShadowColor: [UIColor colorWithWhite:0.0 alpha:0.5],
-     }
-                                 forState:UIControlStateNormal];
+    [neuronLayerItem setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     [neuronLayerItem setTag:barButton_scrollToNeurons];
     [neuronLayerItem setWidth:40.0f];
 

--- a/WormBrowser/OWViewController.m
+++ b/WormBrowser/OWViewController.m
@@ -144,7 +144,7 @@
     
 #else
 
-    loadingActivity = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    loadingActivity = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     [loadingActivity setFrame:CGRectMake(0,0,40,40)];
     [loadingActivity startAnimating];
     [loadingActivity setCenter:CGPointMake(self.view.frame.size.width - 30, 30)];


### PR DESCRIPTION
## Summary
- modernize deprecated NSString APIs in DCRoundSwitch
- clean up draw string methods in DCRoundSwitchToggleLayer
- update iRate to use `requestReviewInScene:` when available
- rework toolbar attribute handling in `OWSearchViewController`
- replace fabsf usage with fabs in `OWMetalViewController`
- migrate metadata view from UIWebView to WKWebView
- use modern activity indicator style
- regenerate Pods project

## Testing
- `./setup.sh`
- `pod install --allow-root`

------
https://chatgpt.com/codex/tasks/task_b_686372df18b4832a9200373c976b542c