### PR TITLE
Fix WKWebView link error and warnings

### DIFF
--- a/OpenWorm.xcodeproj/project.pbxproj
+++ b/OpenWorm.xcodeproj/project.pbxproj
@@ -156,9 +156,10 @@
 		A8F42B5A166ED6D1005503A4 /* OWCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = A8F42B59166ED6D0005503A4 /* OWCamera.m */; };
 		A8F838E01682FE430052531F /* OWMetaDataViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A8F838DF1682FE430052531F /* OWMetaDataViewController.m */; };
 		A8FC9F7B1676ADED000883F3 /* data.json in Resources */ = {isa = PBXBuildFile; fileRef = A8FC9F7A1676ADED000883F3 /* data.json */; };
-		B0B0B0B21600000000000001 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0B0B0B01600000000000001 /* Metal.framework */; };
-		B0B0B0B31600000000000001 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0B0B0B11600000000000001 /* MetalKit.framework */; };
-		B0B0B0B71600000000000001 /* OWMetalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B0B0B51600000000000001 /* OWMetalViewController.m */; };
+                B0B0B0B21600000000000001 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0B0B0B01600000000000001 /* Metal.framework */; };
+                B0B0B0B31600000000000001 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0B0B0B11600000000000001 /* MetalKit.framework */; };
+                6f9b34f5344443908ee75991 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = fe8d38e545184642875054eb /* WebKit.framework */; };
+                B0B0B0B71600000000000001 /* OWMetalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B0B0B51600000000000001 /* OWMetalViewController.m */; };
 		B0B0B0B81600000000000001 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = B0B0B0B61600000000000001 /* Shaders.metal */; };
 		FFA41A257D9AAA264C3867C2 /* libPods-OpenWorm.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6849F52DCA6B27D968C0ECCD /* libPods-OpenWorm.a */; };
 /* End PBXBuildFile section */
@@ -337,8 +338,9 @@
 		B0B0B0B11600000000000001 /* MetalKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		B0B0B0B41600000000000001 /* OWMetalViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWMetalViewController.h; sourceTree = "<group>"; };
 		B0B0B0B51600000000000001 /* OWMetalViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWMetalViewController.m; sourceTree = "<group>"; };
-		B0B0B0B61600000000000001 /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
-		c6e63e19dc8743029a9a5ae3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = WormBrowser/Assets.xcassets; sourceTree = SOURCE_ROOT; };
+                B0B0B0B61600000000000001 /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
+                c6e63e19dc8743029a9a5ae3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = WormBrowser/Assets.xcassets; sourceTree = SOURCE_ROOT; };
+                fe8d38e545184642875054eb /* WebKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -348,12 +350,13 @@
 			files = (
 				A8C8120016A7B67100F3D3C0 /* QuartzCore.framework in Frameworks */,
 				B0B0B0B31600000000000001 /* MetalKit.framework in Frameworks */,
-				B0B0B0B21600000000000001 /* Metal.framework in Frameworks */,
-				A8C710DF166C329D0067DCAC /* UIKit.framework in Frameworks */,
-				A8C710E1166C329D0067DCAC /* Foundation.framework in Frameworks */,
-				A8C710E3166C329D0067DCAC /* CoreGraphics.framework in Frameworks */,
-				FFA41A257D9AAA264C3867C2 /* libPods-OpenWorm.a in Frameworks */,
-			);
+                               B0B0B0B21600000000000001 /* Metal.framework in Frameworks */,
+                               A8C710DF166C329D0067DCAC /* UIKit.framework in Frameworks */,
+                               A8C710E1166C329D0067DCAC /* Foundation.framework in Frameworks */,
+                               A8C710E3166C329D0067DCAC /* CoreGraphics.framework in Frameworks */,
+                               6f9b34f5344443908ee75991 /* WebKit.framework in Frameworks */,
+                               FFA41A257D9AAA264C3867C2 /* libPods-OpenWorm.a in Frameworks */,
+                       );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -541,12 +544,13 @@
 			children = (
 				A8C811FF16A7B67000F3D3C0 /* QuartzCore.framework */,
 				B0B0B0B11600000000000001 /* MetalKit.framework */,
-				B0B0B0B01600000000000001 /* Metal.framework */,
-				A8C710DE166C329D0067DCAC /* UIKit.framework */,
-				A8C710E0166C329D0067DCAC /* Foundation.framework */,
-				A8C710E2166C329D0067DCAC /* CoreGraphics.framework */,
-				6849F52DCA6B27D968C0ECCD /* libPods-OpenWorm.a */,
-			);
+                               B0B0B0B01600000000000001 /* Metal.framework */,
+                               A8C710DE166C329D0067DCAC /* UIKit.framework */,
+                               A8C710E0166C329D0067DCAC /* Foundation.framework */,
+                               A8C710E2166C329D0067DCAC /* CoreGraphics.framework */,
+                               fe8d38e545184642875054eb /* WebKit.framework */,
+                               6849F52DCA6B27D968C0ECCD /* libPods-OpenWorm.a */,
+                       );
 			name = Frameworks;
 			sourceTree = "<group>";
 		};

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -125,12 +125,12 @@
 		2F7EF43285834E1201CFF1EDC7DCFB61 /* DDLoggerNames.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLoggerNames.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDLoggerNames.h; sourceTree = "<group>"; };
 		3DE7BBF5A6D17D198AF583B494DE001A /* Reachability-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Reachability-dummy.m"; sourceTree = "<group>"; };
 		3E195221B09C16FBF67F463C799B7027 /* DCRoundSwitch-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DCRoundSwitch-prefix.pch"; sourceTree = "<group>"; };
-		400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = Reachability; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		494E57B7666B0407CCA71448249CCBC8 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAbstractDatabaseLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
 		4FE113951B345F8CD435B2A92EA0744F /* DDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDMultiFormatter.m; path = Sources/CocoaLumberjack/Extensions/DDMultiFormatter.m; sourceTree = "<group>"; };
-		519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaLumberjackPrivacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		5743B0089D8EB12DE16A9B85BF5AC571 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/CocoaLumberjack/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenWorm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "CocoaLumberjack-CocoaLumberjackPrivacy"; path = CocoaLumberjackPrivacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		5743B0089D8EB12DE16A9B85BF5AC571 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Sources/CocoaLumberjack/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "Pods-OpenWorm"; path = "libPods-OpenWorm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5888868ED4BEBE305471BEE2622337A3 /* DDFileLogger+Buffering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDFileLogger+Buffering.h"; path = "Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger+Buffering.h"; sourceTree = "<group>"; };
 		5B682BF47B2CB06FE9190393E3A2C0D4 /* Pods-OpenWorm-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OpenWorm-acknowledgements.markdown"; sourceTree = "<group>"; };
 		60746F4531504667F98843E3B0E8F5F0 /* DCRoundSwitchToggleLayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitchToggleLayer.m; path = DCRoundSwitch/DCRoundSwitchToggleLayer.m; sourceTree = "<group>"; };
@@ -141,7 +141,7 @@
 		6EE1D9276F2588288752619612A90EDB /* iRate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = iRate.m; path = iRate/iRate.m; sourceTree = "<group>"; };
 		70174B601C27883376341DCA6A81D48D /* CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
 		71348348490DF861FF39BB5ADFCD2A2F /* DDFileLogger+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDFileLogger+Internal.h"; path = "Sources/CocoaLumberjack/DDFileLogger+Internal.h"; sourceTree = "<group>"; };
-		76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libiRate.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		76E6C06FD221258CB81F365A325A0A03 /* iRate */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = iRate; path = libiRate.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		77C82E0ED1D94173CECA22D81BE81092 /* iRate.bundle */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.plug-in"; name = iRate.bundle; path = iRate/iRate.bundle; sourceTree = "<group>"; };
 		7811DF291458E5024EE55468B812ED48 /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDASLLogCapture.h; sourceTree = "<group>"; };
 		797B444314D41B0225573CA930DC7F0C /* DCRoundSwitch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitch.m; path = DCRoundSwitch/DCRoundSwitch.m; sourceTree = "<group>"; };
@@ -159,7 +159,7 @@
 		98ACEBEC52410175AC1FA1757C527583 /* DCRoundSwitch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DCRoundSwitch.debug.xcconfig; sourceTree = "<group>"; };
 		9905349679C288EF642F67ACF9ADF3F0 /* iRate.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iRate.debug.xcconfig; sourceTree = "<group>"; };
 		9A2B538B7EEB42FC2FCB04D6298F86DB /* DCRoundSwitch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DCRoundSwitch.release.xcconfig; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9FA32E3D557E999064508143EF45E1F9 /* iRate.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iRate.release.xcconfig; sourceTree = "<group>"; };
 		A7643FE72683433F275FB0FE106E3553 /* CLIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLIColor.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/CLIColor.h; sourceTree = "<group>"; };
 		A930A47E42A97CED8C01D575EF319645 /* DDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDOSLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h; sourceTree = "<group>"; };
@@ -168,8 +168,8 @@
 		B20B830C516C80274083E737A1280B7C /* Pods-OpenWorm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OpenWorm.release.xcconfig"; sourceTree = "<group>"; };
 		BA05E44D2ECC2BA45EE100AAA0838A07 /* Reachability.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.debug.xcconfig; sourceTree = "<group>"; };
 		C0AE088B28288B8E48899C044548CC0F /* DDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDOSLogger.m; path = Sources/CocoaLumberjack/DDOSLogger.m; sourceTree = "<group>"; };
-		C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libDCRoundSwitch.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = CocoaLumberjack; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = DCRoundSwitch; path = libDCRoundSwitch.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7158AF2308F5A08A9324EE6A13D1877 /* iRate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iRate-prefix.pch"; sourceTree = "<group>"; };
 		C7886F9C3E74DFEF89F52B15DA7EA9B8 /* Reachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		C9A594C871F09029A4BFEFD8A30D39DD /* DCRoundSwitchKnobLayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DCRoundSwitchKnobLayer.m; path = DCRoundSwitch/DCRoundSwitchKnobLayer.m; sourceTree = "<group>"; };
@@ -182,9 +182,9 @@
 		DD675D3B8A66E85F612E60E50A3A3EC9 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Sources/CocoaLumberjack/DDFileLogger.m; sourceTree = "<group>"; };
 		DF578159E4926B5E2E91689E080B83A5 /* Reachability.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.release.xcconfig; sourceTree = "<group>"; };
 		DF9987B561ACDBC060BCA503E9E2F180 /* Pods-OpenWorm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OpenWorm.debug.xcconfig"; sourceTree = "<group>"; };
-		DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Reachability_Privacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Reachability-Reachability_Privacy"; path = Reachability_Privacy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0D5E8837D4B39548FDCC42079A6CA0B /* CLIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CLIColor.m; path = Sources/CocoaLumberjack/CLI/CLIColor.m; sourceTree = "<group>"; };
-		E394A4FF266A1D33C60CBAE6D2B1D4BA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Framework/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E394A4FF266A1D33C60CBAE6D2B1D4BA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Framework/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E6BADD1BF23935D488D0E8A78329607A /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDDispatchQueueLogFormatter.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
 		EB8C56162F8081FB2F769EB506C5036D /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Sources/CocoaLumberjack/DDASLLogger.m; sourceTree = "<group>"; };
 		F00F03D7545ECE48AC9A728C03215CC7 /* Reachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
@@ -292,13 +292,13 @@
 		3494C746B091FF2FEF7E6AEA9ED02A9F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */,
-				519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */,
-				C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */,
-				76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */,
-				57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */,
-				400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */,
-				DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */,
+				C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */,
+				519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */,
+				C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */,
+				76E6C06FD221258CB81F365A325A0A03 /* iRate */,
+				57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */,
+				400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */,
+				DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -332,6 +332,7 @@
 				50D6C6F19FBBD23B28EAA656500175D3 /* Resources */,
 				291F9BEE532815CC6E150AD4C117B4BD /* Support Files */,
 			);
+			name = iRate;
 			path = iRate;
 			sourceTree = "<group>";
 		};
@@ -415,6 +416,7 @@
 				6CC89E93FE4FBFC14619B5097B55B6B1 /* Resources */,
 				3C52E620797B0F19BB1A8A074212EFF8 /* Support Files */,
 			);
+			name = Reachability;
 			path = Reachability;
 			sourceTree = "<group>";
 		};
@@ -424,6 +426,7 @@
 				9D362EB491872DE015C0AE0B90C34347 /* Core */,
 				155B049BE5630BAA7FECAF537B563E41 /* Support Files */,
 			);
+			name = CocoaLumberjack;
 			path = CocoaLumberjack;
 			sourceTree = "<group>";
 		};
@@ -451,6 +454,7 @@
 				60746F4531504667F98843E3B0E8F5F0 /* DCRoundSwitchToggleLayer.m */,
 				14AF438157C350154DB63AA1E5C4F990 /* Support Files */,
 			);
+			name = DCRoundSwitch;
 			path = DCRoundSwitch;
 			sourceTree = "<group>";
 		};
@@ -553,7 +557,7 @@
 			);
 			name = "CocoaLumberjack-CocoaLumberjackPrivacy";
 			productName = CocoaLumberjackPrivacy;
-			productReference = 519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjackPrivacy.bundle */;
+			productReference = 519AF98C92B517DD023896CD077EBFD4 /* CocoaLumberjack-CocoaLumberjackPrivacy */;
 			productType = "com.apple.product-type.bundle";
 		};
 		84126886E76D449731B0A0FCF67406CF /* iRate */ = {
@@ -570,7 +574,7 @@
 			);
 			name = iRate;
 			productName = iRate;
-			productReference = 76E6C06FD221258CB81F365A325A0A03 /* libiRate.a */;
+			productReference = 76E6C06FD221258CB81F365A325A0A03 /* iRate */;
 			productType = "com.apple.product-type.library.static";
 		};
 		890AB6D76FF473D68D81F32DCA15B7F9 /* Pods-OpenWorm */ = {
@@ -591,7 +595,7 @@
 			);
 			name = "Pods-OpenWorm";
 			productName = "Pods-OpenWorm";
-			productReference = 57E6299147628D7C5BD377BFFEC3682B /* libPods-OpenWorm.a */;
+			productReference = 57E6299147628D7C5BD377BFFEC3682B /* Pods-OpenWorm */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CAA047C0F5E4106F3904E8497FA17F97 /* Reachability */ = {
@@ -609,7 +613,7 @@
 			);
 			name = Reachability;
 			productName = Reachability;
-			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */;
+			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */;
 			productType = "com.apple.product-type.library.static";
 		};
 		D2787856C227A709315E3C9C4355A440 /* Reachability-Reachability_Privacy */ = {
@@ -626,7 +630,7 @@
 			);
 			name = "Reachability-Reachability_Privacy";
 			productName = Reachability_Privacy;
-			productReference = DFC89BE171DE7E648C53797695D8A220 /* Reachability_Privacy.bundle */;
+			productReference = DFC89BE171DE7E648C53797695D8A220 /* Reachability-Reachability_Privacy */;
 			productType = "com.apple.product-type.bundle";
 		};
 		E95654B155D25890BE8E26081FCA8265 /* CocoaLumberjack */ = {
@@ -644,7 +648,7 @@
 			);
 			name = CocoaLumberjack;
 			productName = CocoaLumberjack;
-			productReference = C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */;
+			productReference = C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F0A37F0DD96DC99AF6475E9E60E7BCD0 /* DCRoundSwitch */ = {
@@ -661,7 +665,7 @@
 			);
 			name = DCRoundSwitch;
 			productName = DCRoundSwitch;
-			productReference = C5561C4040A0E8D9007DC169626CF747 /* libDCRoundSwitch.a */;
+			productReference = C5561C4040A0E8D9007DC169626CF747 /* DCRoundSwitch */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -670,9 +674,8 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1600;
-				LastUpgradeCheck = 1630;
+				LastUpgradeCheck = 1600;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 12.0";
@@ -683,6 +686,8 @@
 				en,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 3494C746B091FF2FEF7E6AEA9ED02A9F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -847,7 +852,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -943,7 +948,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -967,6 +971,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -987,7 +992,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/DCRoundSwitch/DCRoundSwitch-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1007,6 +1012,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B20B830C516C80274083E737A1280B7C /* Pods-OpenWorm.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1035,7 +1041,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CocoaLumberjack";
 				IBSC_MODULE = CocoaLumberjack;
 				INFOPLIST_FILE = "Target Support Files/CocoaLumberjack/ResourceBundle-CocoaLumberjackPrivacy-CocoaLumberjack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = CocoaLumberjackPrivacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1052,7 +1058,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CocoaLumberjack";
 				IBSC_MODULE = CocoaLumberjack;
 				INFOPLIST_FILE = "Target Support Files/CocoaLumberjack/ResourceBundle-CocoaLumberjackPrivacy-CocoaLumberjack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = CocoaLumberjackPrivacy;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1096,7 +1102,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1116,6 +1121,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -1183,7 +1189,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1212,7 +1218,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1240,7 +1246,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/iRate/iRate-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1268,7 +1274,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1288,6 +1294,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DF9987B561ACDBC060BCA503E9E2F180 /* Pods-OpenWorm.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";

--- a/Pods/iRate/iRate/iRate.m
+++ b/Pods/iRate/iRate/iRate.m
@@ -849,11 +849,32 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         if (!manual && [SKStoreReviewController class])
         {
             [self remindLater];
-            if (@available(iOS 14.0, *)) {
-                UIWindowScene *scene = UIApplication.sharedApplication.windows.firstObject.windowScene;
-                [SKStoreReviewController requestReviewInScene:scene];
-            } else {
+            if (@available(iOS 14.0, *))
+            {
+                UIWindowScene *targetScene = nil;
+                for (UIScene *scene in UIApplication.sharedApplication.connectedScenes)
+                {
+                    if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive)
+                    {
+                        targetScene = (UIWindowScene *)scene;
+                        break;
+                    }
+                }
+                if (targetScene)
+                {
+                    [SKStoreReviewController requestReviewInScene:targetScene];
+                }
+                else
+                {
+                    [SKStoreReviewController requestReview];
+                }
+            }
+            else
+            {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 [SKStoreReviewController requestReview];
+#pragma clang diagnostic pop
             }
         }
         else

--- a/WormBrowser/OWMetaDataViewController.m
+++ b/WormBrowser/OWMetaDataViewController.m
@@ -159,8 +159,6 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     if (contains.location == NSNotFound) {
         if (@available(iOS 10.0, *)) {
             [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-        } else {
-            [[UIApplication sharedApplication] openURL:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
     } else {


### PR DESCRIPTION
## Summary
- suppress deprecated `openURL:` usage
- adapt iRate's rating prompt to avoid deprecated APIs
- link against WebKit framework so WKWebView resolves
- regenerate Pods workspace

## Testing
- `./setup.sh`
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863774487e0832a976063dd0deac5a8