### PR TITLE
Fix compile storyboard error

### DIFF
--- a/OpenWorm.xcodeproj/project.pbxproj
+++ b/OpenWorm.xcodeproj/project.pbxproj
@@ -1070,7 +1070,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WormBrowser/OpenWorm-Prefix.pch";
 				INFOPLIST_FILE = "WormBrowser/OpenWorm-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+                               IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openworm.openwormbrowser-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1089,7 +1089,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WormBrowser/OpenWorm-Prefix.pch";
 				INFOPLIST_FILE = "WormBrowser/OpenWorm-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+                               IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openworm.openwormbrowser-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
## Summary
- fix `IPHONEOS_DEPLOYMENT_TARGET` in Xcode project to use 15.0 instead of 15.6

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68647b0e426c832ab3aaf3058c63c6f3